### PR TITLE
Add private registry capability

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,7 +217,7 @@ SimpleContainerGenerator.create_dockerfile(pkgs;
                                            registry_urls = registry_urls)
 
 # Note: you may need to `ssh-add` your key before this command will work.
-run(`docker build --ssh default -t my_docker_username/my_image_name .`)
+run(`DOCKER_BUILDKIT=1 docker build --ssh default -t my_docker_username/my_image_name .`)
 ```
 
 ## Docker cheatsheet

--- a/README.md
+++ b/README.md
@@ -188,6 +188,38 @@ SimpleContainerGenerator.create_dockerfile(pkgs;
 run(`docker build -t my_docker_username/my_image_name .`)
 ```
 
+### Example 8
+
+```julia
+import SimpleContainerGenerator
+
+mkpath("my_image_name")
+cd("my_image_name")
+
+# Add private registries. General will always be included as a backup.
+# The first method uses your ssh credentials, whereas the second requires a
+# Personal Access Token.
+registry_urls = ["git@github.com:MyCompany/MyPrivateRegistry.git",
+                 "https://username:githubPAT@github.com/MyCompany/AnotherRegistry.git"]
+
+# Optionally, override the URL of your privately registered package. Useful if your registry
+# stores the URIs of your packages as git+ssh, but you wish to use PATs in your workflow.
+pkgs = [
+    (name = "Foo", url = "https://username:githubPAT@github.com/MyCompany/MyPackage.jl.git",),
+    (name = "Bar", ),
+    (name = "Baz", ),
+]
+julia_version = v"1.4.0"
+
+SimpleContainerGenerator.create_dockerfile(pkgs;
+                                           julia_version = julia_version,
+                                           output_directory = pwd(),
+                                           registry_urls = registry_urls)
+
+# Note: you may need to `ssh-add` your key before this command will work.
+run(`docker build --ssh default -t my_docker_username/my_image_name .`)
+```
+
 ## Docker cheatsheet
 
 | Command | Description |

--- a/src/generate_install_packages.jl
+++ b/src/generate_install_packages.jl
@@ -17,6 +17,15 @@ function _to_packagespec_string(pkgs::AbstractVector{<:AbstractDict})
     return "Pkg.Types.PackageSpec[$(join(pkg_strings, ", "))]"
 end
 
+function _to_registries_string(registry_urls::Vector{String})
+    registries = String[]
+    for registry in registry_urls
+        push!(registries, "Pkg.Registry.add(Pkg.RegistrySpec(url = \"" * registry * "\"))")
+    end
+    isempty(registries) || push!(registries, "Pkg.Registry.add(Pkg.RegistrySpec(url = \"https://github.com/JuliaRegistries/General.git\"))")
+    return registries
+end
+
 function _generate_install_packages_content(config::Config)
     pkgs = config.pkgs
     no_test = config.no_test
@@ -30,8 +39,10 @@ function _generate_install_packages_content(config::Config)
         end
     end
     pkgs_string = _to_packagespec_string(pkgs)
+    registries = _to_registries_string(config.registry_urls)
     lines = String[
         "import Pkg",
+        registries...,
         "Pkg.add($(pkgs_string))",
         "for name in $(pkg_names_to_test) # pkg_names_to_test",
         "Pkg.add(name)",

--- a/src/types_config.jl
+++ b/src/types_config.jl
@@ -3,6 +3,7 @@ struct Config
     exclude_packages_from_sysimage::Vector{String}
     julia_cpu_target::String
     julia_version::Union{String, VersionNumber}
+    registry_urls::Vector{String}
     make_sysimage::Bool
     no_test::Vector{String}
     packagecompiler_installation_command::String
@@ -28,6 +29,7 @@ function Config(pkgs::AbstractVector{<:AbstractDict{<:Symbol,<:AbstractString}} 
                             _default_julia_cpu_target(),
                         julia_version::Union{AbstractString, VersionNumber} =
                             _default_julia_version(),
+                        registry_urls = String[],
                         make_sysimage::Bool =
                             true,
                         no_test =
@@ -51,6 +53,7 @@ function Config(pkgs::AbstractVector{<:AbstractDict{<:Symbol,<:AbstractString}} 
                     exclude_packages_from_sysimage,
                     julia_cpu_target,
                     julia_version,
+                    registry_urls,
                     make_sysimage,
                     no_test,
                     packagecompiler_installation_command,


### PR DESCRIPTION
Closes #102 

It's geared directly at github, but I think it's general enough at this point (the known hosts step can be extended to gitlab or whatever if users request that). No credentials are stored anywhere, so no problems there. The PAT route isn't the best, but I doubt many organisations use that method.